### PR TITLE
Implement 'libgomp/plugin/plugin-host_process.c:call_function_with_args'

### DIFF
--- a/libgomp/plugin/plugin-host_process.c
+++ b/libgomp/plugin/plugin-host_process.c
@@ -56,7 +56,9 @@ GOMP_OFFLOAD_get_num_devices (unsigned int omp_requires_mask)
 bool
 call_function_with_args(void *fn_ptr, void *vars)
 {
-    return false;
+    void (*fn) (void *) = fn_ptr;
+    fn(vars);
+    return true;
 }
 
 


### PR DESCRIPTION
With this, basic OpenMP 'target' programs do work, congratulations!  :smile: